### PR TITLE
processing: Add more options

### DIFF
--- a/mandown/converter.py
+++ b/mandown/converter.py
@@ -149,7 +149,10 @@ class Converter:
             with open(oebps / "content.opf", "w", encoding="utf-8") as file:
                 file.write(
                     EpubGenerator.generate_content_opf(
-                        self.metadata, self.chapters, self.cover
+                        self.metadata,
+                        self.chapters,
+                        PageProgression.LEFT_TO_RIGHT,
+                        self.cover,
                     )
                 )
 

--- a/mandown/converter.py
+++ b/mandown/converter.py
@@ -1,7 +1,9 @@
 """
 Converts a folder of images to EPUB/PDF/CBZ/MOBI
 """
+from dataclasses import dataclass
 import datetime
+from enum import Enum
 import os
 import re
 import shutil
@@ -28,12 +30,23 @@ ACCEPTED_IMAGE_EXTENSIONS = {
 KOBO_WIDTH, KOBO_HEIGHT = 1005, 1430
 
 
+class PageProgression(str, Enum):
+    LEFT_TO_RIGHT = "ltr"
+    RIGHT_TO_LEFT = "rtl"
+
+
+@dataclass
+class Options:
+    page_progression: PageProgression = PageProgression.LEFT_TO_RIGHT
+
+
 class Converter:
     def __init__(
         self,
         folder_path: str,
         metadata: MangaMetadata | None = None,
         chapter_list: list[tuple[str, str]] | None = None,
+        options: Options | None = None,
     ) -> None:
         """
         Get the file path of a comic and identify its metadata.
@@ -104,6 +117,7 @@ class Converter:
             "epub": len(self.chapters) * 3,
             "cbz": len(self.chapters),
         }
+        self.options = options or Options()
 
     def to_cbz_progress(self, dest_folder: str) -> Iterator:
         dest_file = Path(dest_folder) / f"{self.metadata.title}.cbz"
@@ -305,6 +319,7 @@ class EpubGenerator:
     def generate_content_opf(
         metadata: MangaMetadata,
         chapters: list[tuple[str, str, str, list[str]]],
+        progression: PageProgression,
         cover: Path | None = None,
     ) -> str:
         """
@@ -375,7 +390,7 @@ class EpubGenerator:
             {cover_html}
             {(chr(10) + " "*12).join(item_ids)}
             </manifest>
-            <spine page-progression-direction="ltr" toc="ncx">
+            <spine page-progression-direction="{progression.value}" toc="ncx">
             {(chr(10) + " "*12).join(item_refs)}
             </spine>
             </package>\

--- a/mandown/processing.py
+++ b/mandown/processing.py
@@ -133,8 +133,3 @@ def process(
 ) -> None:
     for _ in process_progress(folder_paths, options, maxthreads):
         pass
-
-
-if __name__ == "__main__":
-    p = Processor("/media/cbz/Horimiya/Page. 1/05.jpeg")
-    p.trim_borders()

--- a/mandown/processing.py
+++ b/mandown/processing.py
@@ -13,19 +13,28 @@ class ProcessOps(str, Enum):
 
     ROTATE_DOUBLE_PAGES = "rotate_double_pages"
     """If page width is greater than its height, rotate it 90 degrees."""
+    SPLIT_DOUBLE_PAGES = "split_double_pages"
+    """If page width is greater than its height, split it in half into two images."""
     NO_POSTPROCESSING = "none"
     """Disable image processing entirely."""
+    TRIM_BORDERS = "trim_borders"
 
 
 class Processor:
-    def __init__(self, image_path: Path | str) -> None:
+    def __init__(self, image_path: Path | str, right_to_left: bool = False) -> None:
         self.image_path = Path(image_path)
         self.image = Image.open(self.image_path)
         self.modified = False
+        self.right_to_left = right_to_left
+
+        self.pending_images: list[tuple[Image.Image, Path]] = []
 
     def write(self, filename: Path | str | None = None) -> None:
         """Save the processed image manually"""
         self.image.save(filename or self.image_path)
+
+        for image, path in self.pending_images:
+            image.save(path)
 
     def process(
         self, operations: list[ProcessOps], filename: Path | str | None = None
@@ -57,6 +66,20 @@ class Processor:
         if width > height:
             self.image = self.image.rotate(90, expand=1)
             self.modified = True
+
+    def split_double_pages(self) -> None:
+        width, height = self.image.size
+        if not width > height:
+            return
+
+        left = self.image.crop((0, 0, int(width / 2), height))
+        right = self.image.crop((int(width / 2), 0, width, height))
+
+        self.image = right if self.right_to_left else left
+        new_image = left if self.right_to_left else right
+
+        new_image_path = self.image_path.with_stem(self.image_path.stem + ".5")
+        self.pending_images.append((new_image, new_image_path))
 
 
 def async_process(data: tuple[Path | str, list[ProcessOps]]) -> None:

--- a/mandown/processing.py
+++ b/mandown/processing.py
@@ -3,7 +3,12 @@ from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
-from PIL import Image, ImageChops
+try:
+    from PIL import Image, ImageChops
+
+    HAS_PILLOW = True
+except ImportError:
+    HAS_PILLOW = False
 
 
 class ProcessOps(str, Enum):
@@ -23,6 +28,10 @@ class ProcessOps(str, Enum):
 
 class Processor:
     def __init__(self, image_path: Path | str, right_to_left: bool = False) -> None:
+        if not HAS_PILLOW:
+            raise ImportError(
+                "Pillow was not found and is needed for processing. Is it installed?"
+            )
         self.image_path = Path(image_path)
         self._image = Image.open(self.image_path)
         self.modified = False


### PR DESCRIPTION
To bring up to (relative) feature parity with KCC, the following features have to be implemented:

- [x] Splitting double pages
- [ ] ~~Splitting and rotating double pages~~
- [x] Trimming page borders
- [ ] ~~Stretch/upscale~~
- [x] left-to-right in EPUB (more converting less processing) (`<spine toc="..." page-progression-direction="rtl">` in content.opf)
- [ ] ~~brightness adjustment~~
- [ ] ~~losslessly/lossily compress images~~