### PR TITLE
Fix many things

### DIFF
--- a/mandown/__init__.py
+++ b/mandown/__init__.py
@@ -8,3 +8,6 @@ from .api import (  # isort: skip
     query,
     read,
 )
+
+__version__ = (0, 9, 0)
+__version_str__ = ".".join(map(str, __version__))

--- a/mandown/api.py
+++ b/mandown/api.py
@@ -86,7 +86,7 @@ def process(comic_path: Path | str, ops: list[ProcessOps]) -> None:
 
 
 def download_progress(
-    comic: BaseComic,
+    comic: BaseComic | str,
     path: Path | str = ".",
     *,
     start: int | None = None,
@@ -95,7 +95,7 @@ def download_progress(
     only_download_missing: bool = True,
 ) -> Iterable:
     """
-    Download comic `comic` to `path` using `threads` threads.
+    Download comic or comic URL `comic` to `path` using `threads` threads.
 
     If `start` or `end` are specified, only download those
     chapters (one-indexed).
@@ -107,6 +107,10 @@ def download_progress(
     number of chapters in the comic.
     """
     path = Path(path)
+
+    # make var comic a BaseComic
+    if isinstance(comic, str):
+        comic = query(comic)
 
     # create dir
     try:
@@ -170,7 +174,7 @@ def download_progress(
 
 
 def download(
-    comic: BaseComic,
+    comic: BaseComic | str,
     path: Path | str = ".",
     *,
     start: int | None = None,
@@ -179,7 +183,7 @@ def download(
     only_download_missing: bool = True,
 ) -> None:
     """
-    Download comic `comic` to `path` using `threads` threads.
+    Download comic or comic URL `comic` to `path` using `threads` threads.
 
     If `start` or `end` are specified, only download those
     chapters (one-indexed).

--- a/mandown/api.py
+++ b/mandown/api.py
@@ -135,10 +135,13 @@ def download_progress(
     # for each chapter
     for chap in comic.chapters[start:end]:
         image_urls = comic.get_chapter_image_urls(chap)
+        chapter_path = full_path / chap.slug
+        chapter_path.mkdir(exist_ok=True)
+
         # expect that they're named by numbers only
         skip_images: set[int] = set()
         if only_download_missing:
-            for file in path.iterdir():
+            for file in chapter_path.iterdir():
                 if file.stem == file.stem.rjust(iohandler.NUM_LEFT_PAD_DIGITS, "0"):
                     try:
                         skip_images.add(int(file.stem))
@@ -147,7 +150,7 @@ def download_progress(
                         pass
 
         if not image_urls or len(skip_images) == len(image_urls):
-            # skip processing if there's nothing to download
+            # move to next chapter if there's nothing to download for this one
             continue
 
         # name them 00001.png, 00002.png, etc
@@ -159,8 +162,6 @@ def download_progress(
                 if i not in skip_images
             )
         )
-
-        chapter_path = full_path / chap.slug
 
         for _ in iohandler.download_images(
             processed_image_urls,

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
-import importlib.metadata
 from pathlib import Path
 from typing import List, Optional
 
 import typer
 
-from . import api, sources
+from . import __version_str__, api, sources
 from .comic import BaseComic
 from .converter.base_converter import ConvertFormats
 from .processor import ProcessOps
@@ -208,7 +207,7 @@ def callback(
     ),
 ) -> None:
     if version:
-        typer.echo(f"mandown {importlib.metadata.version('mandown')}")
+        typer.echo(f"mandown {__version_str__}")
         raise typer.Exit()
 
     if supported_sites:

--- a/mandown/iohandler.py
+++ b/mandown/iohandler.py
@@ -101,7 +101,6 @@ def save_comic(comic: BaseComic, path: Path | str) -> None:
     path.mkdir(exist_ok=True)
 
     json_path = path / MD_METADATA_FILE
-    print(comic.asdict())
 
     with open(json_path, "w", encoding="utf-8") as file:
         json.dump(comic.asdict(), file)


### PR DESCRIPTION
The signature is now `def download(comic: BaseComic | str, ...)`. If a `str` is provided, Mandown will `query` it.

Also use metafile for versioning.

Resolves #39, #37 