### PR TITLE
feat: add cleanup flag for converting and downloading

### DIFF
--- a/mandown/api.py
+++ b/mandown/api.py
@@ -21,7 +21,10 @@ def query(url: str) -> BaseComic:
 def load(path: Path | str) -> BaseComic:
     """
     Load a mandown-created comic from the file system.
+
     :param `path`: A folder where mandown has created a comic
+    :returns A comic with metadata and chapter data of that folder
+
     :throws FileNotFoundError if `md-metadata.json` cannot be found.
     """
     return io.read_comic(path)
@@ -30,6 +33,9 @@ def load(path: Path | str) -> BaseComic:
 def save_metadata(comic: BaseComic, path: Path | str) -> None:
     """
     Save the metadata from the comic to `<path>/md-metadata.json`.
+
+    :param `comic`: A comic with metadata to save
+    :param `path`: A folder to save the metadata to
     """
     io.save_comic(comic, path)
 
@@ -62,10 +68,13 @@ def convert_progress(
     From metadata in `comic`, convert the comic in `folder_path`
     to `convert_to` and put it in `dest_folder` (defaults to workdir).
 
-    :param `remove_after`: If `True`, delete the original folder after conversion.
+    :param `comic`: A comic with metadata to convert
+    :param `folder_path`: A folder containing the comic to convert
+    :param `convert_to`: The format to convert to
+    :param `dest_folder`: A folder to put the converted comic in
+    :param `remove_after`: If `True`, delete the original folder after conversion
 
-    Returns an Iterator representing a progress bar up to the
-    number of chapters in the comic.
+    :returns An `Iterator` representing a progress bar up to the number of chapters in the comic.
     """
     if convert_to == ConvertFormats.NONE:
         return
@@ -92,7 +101,11 @@ def convert(
     From metadata in `comic`, convert the comic in `folder_path`
     to `convert_to` and put it in `dest_folder` (defaults to workdir).
 
-    :param `remove_after`: If `True`, delete the original folder after conversion.
+    :param `comic`: A comic with metadata to convert
+    :param `folder_path`: A folder containing the comic to convert
+    :param `convert_to`: The format to convert to
+    :param `dest_folder`: A folder to put the converted comic in
+    :param `remove_after`: If `True`, delete the original folder after conversion
     """
     for _ in convert_progress(
         comic, folder_path, convert_to, dest_folder, remove_after
@@ -104,8 +117,9 @@ def process_progress(comic_path: Path | str, ops: list[ProcessOps]) -> Iterator[
     """
     Process the comic in `comic_path` with `ops` in the order provided.
 
-    Returns an Iterator representing a progress bar up to the
-    number of chapters in the comic.
+    :param `comic_path`: A folder containing a image folders to process
+    :param `ops`: A list of operations to perform on each image
+    :returns An `Iterator` representing a progress bar up to the number of images in the comic.
     """
     data = io.discover_local_images(comic_path)
     for _, images in data.items():
@@ -117,6 +131,10 @@ def process_progress(comic_path: Path | str, ops: list[ProcessOps]) -> Iterator[
 def process(comic_path: Path | str, ops: list[ProcessOps]) -> None:
     """
     Process the comic in `comic_path` with `ops` in the order provided.
+
+    :param `comic_path`: A folder containing a image folders to process
+    :param `ops`: A list of operations to perform on each image
+    :returns An `Iterator` representing a progress bar up to the number of images in the comic.
     """
     for _ in process_progress(comic_path, ops):
         pass
@@ -134,14 +152,14 @@ def download_progress(
     """
     Download comic or comic URL `comic` to `path` using `threads` threads.
 
-    If `start` or `end` are specified, only download those
-    chapters (one-indexed).
+    :param `comic`: A comic or URL to download
+    :param `path`: A folder to download the comic to
+    :param `start`: The first chapter to download (one-indexed, inclusive)
+    :param `end`: The last chapter to download (one-indexed, inclusive)
+    :param `threads`: The number of threads to use
+    :param `only_download_missing`: If `True`, do not download images already in the destination path
 
-    If `only_download_missing` is `True`, images already in the
-    destination path will not be downloaded again.
-
-    Returns an Iterator representing a progress bar up to the
-    number of chapters in the comic.
+    :returns An `Iterator` representing a progress bar up to the number of chapters in the comic.
     """
     path = Path(path)
 
@@ -225,11 +243,12 @@ def download(
     """
     Download comic or comic URL `comic` to `path` using `threads` threads.
 
-    If `start` or `end` are specified, only download those
-    chapters (one-indexed).
-
-    If `only_download_missing` is `True`, images already in the
-    destination path will not be downloaded again.
+    :param `comic`: A comic or URL to download
+    :param `path`: A folder to download the comic to
+    :param `start`: The first chapter to download (one-indexed, inclusive)
+    :param `end`: The last chapter to download (one-indexed, inclusive)
+    :param `threads`: The number of threads to use
+    :param `only_download_missing`: If `True`, do not download images already in the destination path
     """
     for _ in download_progress(
         comic,

--- a/mandown/api.py
+++ b/mandown/api.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from typing import Iterator
 
@@ -55,10 +56,13 @@ def convert_progress(
     folder_path: Path | str,
     convert_to: ConvertFormats,
     dest_folder: Path | str | None = None,
+    remove_after: bool = False,
 ) -> Iterator[str]:
     """
     From metadata in `comic`, convert the comic in `folder_path`
     to `convert_to` and put it in `dest_folder` (defaults to workdir).
+
+    :param `remove_after`: If `True`, delete the original folder after conversion.
 
     Returns an Iterator representing a progress bar up to the
     number of chapters in the comic.
@@ -73,18 +77,26 @@ def convert_progress(
     converter = get_converter(convert_to)(comic)  # pylint: disable=not-callable
     yield from converter.create_file_progress(folder_path, dest_folder)
 
+    if remove_after:
+        shutil.rmtree(folder_path)
+
 
 def convert(
     comic: BaseComic,
     folder_path: Path | str,
     convert_to: ConvertFormats,
     dest_folder: Path | str | None = None,
+    remove_after: bool = False,
 ) -> None:
     """
     From metadata in `comic`, convert the comic in `folder_path`
     to `convert_to` and put it in `dest_folder` (defaults to workdir).
+
+    :param `remove_after`: If `True`, delete the original folder after conversion.
     """
-    for _ in convert_progress(comic, folder_path, convert_to, dest_folder):
+    for _ in convert_progress(
+        comic, folder_path, convert_to, dest_folder, remove_after
+    ):
         pass
 
 

--- a/mandown/base.py
+++ b/mandown/base.py
@@ -5,6 +5,18 @@ from slugify import slugify
 
 @dataclass(slots=True)
 class BaseMetadata:
+    """
+    Metadata for a comic.
+
+    :param `title`: The title of the comic
+    :param `authors`: A list of authors of the comic
+    :param `url`: The URL of the comic
+    :param `genres`: A list of genres of the comic
+    :param `description`: A description of the comic
+    :param `cover_art`: The URL of the cover art
+    :param `title_slug`: The slug of the title
+    """
+
     title: str
     authors: list[str]
     url: str
@@ -17,6 +29,10 @@ class BaseMetadata:
         self.title_slug = slugify(self.title)
 
     def asdict(self) -> dict:
+        """
+        Return a dictionary representation of the metadata.
+        """
+
         return {
             "title": self.title,
             "authors": self.authors,
@@ -29,6 +45,14 @@ class BaseMetadata:
 
 @dataclass(slots=True)
 class BaseChapter:
+    """
+    A chapter of a comic.
+
+    :param `title`: The title of the chapter
+    :param `url`: The URL of the chapter
+    :param `slug`: The slug of the chapter
+    """
+
     title: str
     url: str
     slug: str = ""
@@ -38,6 +62,9 @@ class BaseChapter:
             self.slug = slugify(self.title)
 
     def asdict(self) -> dict:
+        """
+        Return a dictionary representation of the chapter.
+        """
         return {
             "title": self.title,
             "url": self.url,

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -26,7 +26,10 @@ def cli_query(url: str) -> BaseComic:
 
 
 def cli_convert(
-    comic_path: Path, target_format: ConvertFormats, dest_folder: Path = Path.cwd()
+    comic_path: Path,
+    target_format: ConvertFormats,
+    dest_folder: Path = Path.cwd(),
+    remove_after: bool = False,
 ) -> None:
     try:
         comic = api.load(comic_path)
@@ -38,7 +41,9 @@ def cli_convert(
         raise typer.Exit(1) from err
 
     with typer.progressbar(
-        api.convert_progress(comic, comic_path, target_format, dest_folder),
+        api.convert_progress(
+            comic, comic_path, target_format, dest_folder, remove_after
+        ),
         length=len(comic.chapters),
         label="Converting",
     ) as progress:
@@ -83,6 +88,12 @@ def convert(
         "-d",
         help="The folder to save the converted file to.",
     ),
+    remove_after: bool = typer.Option(
+        False,
+        "--remove-after",
+        "-r",
+        help="Remove the the original folder after conversion",
+    ),
 ) -> None:
     """
     Convert a comic folder into CBZ/EPUB/PDF.
@@ -100,7 +111,7 @@ def convert(
         f"Found {comic.metadata.title} with {len(comic.chapters)} chapters, "
         f"converting to {convert_to}..."
     )
-    cli_convert(folder_path, convert_to, dest)
+    cli_convert(folder_path, convert_to, dest, remove_after)
 
 
 @app.command()
@@ -143,6 +154,12 @@ def get(
         "-p",
         help="Image processing options (in-place)",
         case_sensitive=True,
+    ),
+    remove_after: bool = typer.Option(
+        False,
+        "--remove-after",
+        "-r",
+        help="Remove the downloaded folder after processing",
     ),
 ) -> None:
     """
@@ -188,7 +205,7 @@ def get(
 
     # convert
     if convert_to != ConvertFormats.NONE:
-        cli_convert(dest / comic.metadata.title, convert_to, dest)
+        cli_convert(dest / comic.metadata.title, convert_to, dest, remove_after)
 
 
 @app.command(name="init-metadata")

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -159,7 +159,7 @@ def get(
         False,
         "--remove-after",
         "-r",
-        help="Remove the downloaded folder after processing",
+        help="Remove the downloaded folder after converting (requires --convert)",
     ),
 ) -> None:
     """

--- a/mandown/comic.py
+++ b/mandown/comic.py
@@ -4,6 +4,13 @@ from .sources.base_source import BaseSource
 
 
 class BaseComic:
+    """
+    A comic with metadata and chapter data.
+
+    :param `metadata`: Metadata of the comic
+    :param `chapters`: A list of chapters of the comic
+    """
+
     def __init__(
         self,
         metadata: BaseMetadata,
@@ -20,6 +27,10 @@ class BaseComic:
                 raise ValueError from err
 
     def asdict(self) -> dict:
+        """
+        Return a dictionary representation of the comic.
+        """
+
         return {
             "metadata": self.metadata.asdict(),
             "chapters": [c.asdict() for c in self.chapters],
@@ -29,6 +40,9 @@ class BaseComic:
         """
         Fetch a list of image URLs of a chapter based on the
         current source.
+
+        :param `chapter`: The chapter to fetch
+        :return: A list of image URLs
         """
         return self.source.fetch_chapter_image_list(chapter)
 
@@ -37,6 +51,9 @@ class BaseComic:
     ) -> None:
         """
         `start` and `end` are zero-indexed.
+
+        :param `start`: The index of the first chapter to keep
+        :param `end`: The index of the last chapter to keep
         """
         self.chapters = self.chapters[start:end]
 

--- a/mandown/converter/__init__.py
+++ b/mandown/converter/__init__.py
@@ -3,6 +3,12 @@ from .base_converter import BaseConverter, ConvertFormats
 
 
 def get_converter(convert_to: ConvertFormats) -> type[BaseConverter]:
+    """
+    Get the converter class for a given format.
+
+    :param `convert_to`: The format to convert to
+    :returns The converter class for `convert_to` (e.g., `CbzConverter` for `ConvertFormats.CBZ`)
+    """
     match convert_to:
         case ConvertFormats.CBZ:
             return cbz.CbzConverter

--- a/mandown/converter/base_converter.py
+++ b/mandown/converter/base_converter.py
@@ -15,6 +15,10 @@ ACCEPTED_IMAGE_EXTENSIONS = {
 
 
 class ConvertFormats(str, Enum):
+    """
+    The formats that mandown can convert to. This is used for the `--format` option.
+    """
+
     # for typing purposes
     CBZ = "cbz"
     EPUB = "epub"
@@ -24,10 +28,23 @@ class ConvertFormats(str, Enum):
 
 @dataclass(kw_only=True, slots=True)
 class ConvertOptions:
+    """
+    Options for converters.
+
+    :param `page_progression`: The page progression of the comic. This is used for EPUBs.
+    """
+
     page_progression: Literal["rtl"] | Literal["ltr"] = "ltr"
 
 
 class BaseConverter:
+    """
+    Base class for converters.
+
+    :param `comic`: A comic with metadata to convert
+    :param `options`: Options for the converter
+    """
+
     def __init__(self, comic: BaseComic, options: ConvertOptions | None = None) -> None:
         self.comic = comic
         self.options = options or ConvertOptions()
@@ -35,13 +52,33 @@ class BaseConverter:
         self.__post_init__()
 
     def __post_init__(self) -> None:
-        pass
+        """
+        Post-initialization hook. This is called after the constructor has finished, and is useful for setting up the converter.
+        """
 
     def create_file_progress(
         self, path: Path | str, save_to: Path | str
     ) -> Iterator[str]:
+        """
+        Convert the comic in `path` and save it to `save_to`.
+
+        :param `path`: A folder containing the comic to convert
+        :param `save_to`: A folder to put the converted comic in
+
+        :returns An `Iterator` representing a progress bar up to the number of chapters in the comic.
+
+        :raises `NotImplementedError`: If the converter is not supported yet.
+        """
         raise NotImplementedError
 
     def create_file(self, path: Path | str, save_to: Path | str) -> None:
+        """
+        Convert the comic in `path` and save it to `save_to`.
+
+        :param `path`: A folder containing the comic to convert
+        :param `save_to`: A folder to put the converted comic in
+
+        :raises `NotImplementedError`: If the converter is not supported yet.
+        """
         for _ in self.create_file_progress(path, save_to):
             pass

--- a/mandown/io.py
+++ b/mandown/io.py
@@ -21,6 +21,11 @@ MD_METADATA_FILE = "md-metadata.json"
 def async_download_image(
     data: tuple[str, Path | str, str | None, dict[str, str] | None]
 ) -> None:
+    """
+    Download an image from a URL to a destination folder, fixing the file extension if necessary.
+
+    :param `data`: A tuple of the url, destination folder, filename, and headers.
+    """
     url, dest_folder, filename, headers = data
     dest_folder = Path(dest_folder)
 
@@ -50,11 +55,13 @@ def download_images(
     """
     Download one or multiple URLs to a destination folder.
     Raises ValueError if the folder does not exist.
+
     :param `urls`: A list of URLs to download.
     :param `dest_folder`: The path to download files into.
     :param `filestems`: Specify the name of each downloaded file instead of the default.
     :param `headers`: Request headers
     :param `threads`: The number of processes to open
+    :returns An iterator that yields `None` for each downloaded file.
     """
     dest_folder = Path(dest_folder)
 
@@ -78,6 +85,7 @@ def download_images(
 def read_comic(path: Path | str) -> BaseComic:
     """
     Open a comic from a folder path.
+
     :param `path`: A folder containing `md-metadata.json`
     :returns A comic with metadata and chapter data of that folder
     :raises `FileNotFoundError` if `md-metadata.json` is not found
@@ -97,7 +105,10 @@ def read_comic(path: Path | str) -> BaseComic:
 def parse_comic(path: Path | str, source_url: str | None = None) -> BaseComic:
     """
     Parse and return an incomplete comic (without most metadata)
-    :param `url`: A source URL to fill metadata from
+
+    :param `path`: A folder containing images
+    :param `source_url`: A source URL to fill metadata from
+    :returns A `BaseComic` with metadata and chapter data of that folder
     """
     path = Path(path)
 
@@ -128,6 +139,9 @@ def parse_comic(path: Path | str, source_url: str | None = None) -> BaseComic:
 def save_comic(comic: BaseComic, path: Path | str) -> None:
     """
     Save an `md-metadata.json` from `comic` into `path`.
+
+    :param `comic`: A comic to save
+    :param `path`: A folder to save `md-metadata.json` into
     """
     path = Path(path)
     path.mkdir(exist_ok=True)
@@ -142,6 +156,9 @@ def discover_local_images(path: Path | str) -> dict[str, list[Path]]:
     """
     Given a comic path, return a dictionary of slugs: images.
     Basically a slightly modified version of os.walk.
+
+    :param `path`: A folder containing images
+    :returns A dictionary of {slugs: images}
     """
     path = Path(path)
 

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -30,6 +30,12 @@ class ProcessOps(str, Enum):
 
 
 class Processor:
+    """
+    A class for processing images.
+
+    :param `image_path`: The path to the image to process
+    """
+
     def __init__(self, image_path: Path | str) -> None:
         if not HAS_PILLOW:
             raise ImportError(
@@ -46,6 +52,12 @@ class Processor:
 
     @property
     def image(self) -> Image.Image:
+        """
+        The image to process. This is a `PIL.Image.Image` object.
+
+        :setter: Set the image to process
+        :returns: The image to process
+        """
         return self._image
 
     @image.setter
@@ -70,6 +82,11 @@ class Processor:
         Perform the operations in `operations` on the image in sequence
         and save it to disk. If `filename` is not None, it will be saved
         with that filename instead.
+
+        :param operations: A list of operations to perform on the image
+        :param filename: The filename to save the image as
+        :raises NotImplementedError: If an operation is not implemented
+        :raises OSError: If there is an error in saving the image
         """
         if ProcessOps.NO_POSTPROCESSING in operations:
             return

--- a/mandown/processor/ops.py
+++ b/mandown/processor/ops.py
@@ -28,6 +28,9 @@ class ProcessContainer:
 
     @staticmethod
     def rotate_double_pages(image: Image.Image) -> Image.Image | None:
+        """
+        Rotate the image 90 degrees if it is a double page so it fits on the screen.
+        """
         width, height = image.size
         if width > height:
             return image.rotate(90, expand=1)
@@ -37,6 +40,9 @@ class ProcessContainer:
     def split_double_pages(
         image: Image.Image,
     ) -> tuple[Image.Image, Image.Image] | None:
+        """
+        Split the image into two separate images if it is a double page.
+        """
         width, height = image.size
         if not width > height:
             return None
@@ -47,6 +53,9 @@ class ProcessContainer:
 
     @staticmethod
     def trim_borders(image: Image.Image) -> Image.Image | None:
+        """
+        Trim the borders of the image.
+        """
         bg = Image.new(image.mode, image.size, image.getpixel((0, 0)))
         diff = ImageChops.difference(image, bg)
         diff = ImageChops.add(diff, diff, 2.0, -100)

--- a/mandown/sources/base_source.py
+++ b/mandown/sources/base_source.py
@@ -2,6 +2,10 @@ from ..base import BaseChapter, BaseMetadata
 
 
 class BaseSource:
+    """
+    An object representing network state for fetching data of a comic.
+    """
+
     name = "Source name goes here"
     domains = ["Source domains goes here"]
     headers: dict[str, str] = {}
@@ -10,13 +14,14 @@ class BaseSource:
     _chapters: list[BaseChapter] = []
 
     def __init__(self, url: str):
-        """
-        An object representing network state for fetching data of a comic.
-        """
+
         self.url = url
 
     @property
     def metadata(self) -> BaseMetadata:
+        """
+        Return the metadata of the comic, fetching and caching it if necessary.
+        """
         if self._metadata:
             return self._metadata
         self._metadata = self.fetch_metadata()
@@ -24,6 +29,9 @@ class BaseSource:
 
     @property
     def chapters(self) -> list[BaseChapter]:
+        """
+        Return the chapter list of the comic, fetching and caching it if necessary.
+        """
         if self._chapters:
             return self._chapters
         self._chapters = self.fetch_chapter_list()


### PR DESCRIPTION
This PR adds a new option sprinkled throughout Mandown to make it easier for people who want to use it once and be done with Mandown.

Specifically, after conversion, the original folder of images can be automatically deleted.

- API: `mandown.convert` and `mandown.convert_progress` now accept `remove_after: bool = False` to delete the original folder after conversion.
- CLI: `mandown get --convert <FORMAT> --remove-after` or `mandown convert <FORMAT> --remove-after` was added (shorthand `-r`).
- Lots of documentation updates!