### PR TITLE
feat(process): add device profiles

### DIFF
--- a/mandown/__init__.py
+++ b/mandown/__init__.py
@@ -8,8 +8,16 @@ from .api import (
     process_progress,
     query,
 )
+from .base import BaseChapter, BaseMetadata
+from .comic import BaseComic
 from .converter import ConvertFormats, get_converter
-from .processor import ProcessConfig, ProcessOps, Processor
+from .io import MD_METADATA_FILE
+from .processor import (
+    ProcessConfig,
+    ProcessOps,
+    ProcessOptionMismatchError,
+    Processor,
+)
 from .processor.profiles import SupportedProfiles, all_profiles
 
 __version__ = (1, 1, 1)

--- a/mandown/__init__.py
+++ b/mandown/__init__.py
@@ -10,6 +10,7 @@ from .api import (
 )
 from .converter import ConvertFormats, get_converter
 from .processor import ProcessConfig, ProcessOps, Processor
+from .processor.profiles import SupportedProfiles, all_profiles
 
 __version__ = (1, 1, 1)
 __version_str__ = ".".join(map(str, __version__))

--- a/mandown/__init__.py
+++ b/mandown/__init__.py
@@ -8,6 +8,8 @@ from .api import (
     process_progress,
     query,
 )
+from .converter import ConvertFormats, get_converter
+from .processor import ProcessConfig, ProcessOps, Processor
 
 __version__ = (1, 1, 1)
 __version_str__ = ".".join(map(str, __version__))

--- a/mandown/api.py
+++ b/mandown/api.py
@@ -162,7 +162,8 @@ def download_progress(
     :param `start`: The first chapter to download (one-indexed, inclusive)
     :param `end`: The last chapter to download (one-indexed, inclusive)
     :param `threads`: The number of threads to use
-    :param `only_download_missing`: If `True`, do not download images already in the destination path
+    :param `only_download_missing`: If `True`, do not download
+    images already in the destination path
 
     :returns An `Iterator` representing a progress bar up to the number of chapters in the comic.
     """
@@ -253,7 +254,8 @@ def download(
     :param `start`: The first chapter to download (one-indexed, inclusive)
     :param `end`: The last chapter to download (one-indexed, inclusive)
     :param `threads`: The number of threads to use
-    :param `only_download_missing`: If `True`, do not download images already in the destination path
+    :param `only_download_missing`: If `True`, do not download images
+    already in the destination path
     """
     for _ in download_progress(
         comic,

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -149,7 +149,7 @@ def process(
     size_profile: Optional[str] = typer.Option(
         None,
         "--profile",
-        "-p",
+        "-r",
         help="RESIZE ONLY: The device profile to use (cannot be used with `target-size`)",
     ),
 ) -> None:
@@ -210,7 +210,7 @@ def get(
     size_profile: Optional[str] = typer.Option(
         None,
         "--profile",
-        "-p",
+        "-r",
         help="IF PROCESSING AND RESIZING: The device profile to use",
     ),
     remove_after: bool = typer.Option(

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -5,13 +5,18 @@ from typing import List, Optional
 
 import typer
 
-from . import __version_str__, all_profiles, api, sources
-from .comic import BaseComic
-from .converter.base_converter import ConvertFormats
-from .io import MD_METADATA_FILE
-from .processor import ProcessOps, ProcessOptionMismatchError
-from .processor.ops import ProcessConfig
-from .processor.profiles import SupportedProfilesEnum
+from . import (
+    MD_METADATA_FILE,
+    BaseComic,
+    ConvertFormats,
+    ProcessConfig,
+    ProcessOps,
+    ProcessOptionMismatchError,
+    __version_str__,
+    all_profiles,
+    api,
+    sources,
+)
 
 app = typer.Typer()
 

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -160,9 +160,8 @@ def process(
             target_size=target_size,
             output_profile=size_profile,
         )
-    except ValueError as err:
-        raise typer.Exit(1) from err
-    except KeyError as err:
+    except Exception as err:
+        typer.secho(f"Could not apply processing options: {err}", fg=typer.colors.RED)
         raise typer.Exit(1) from err
     cli_process(folder_path, options, config)
 
@@ -263,10 +262,17 @@ def get(
 
     # process
     if processing_options:
-        config = ProcessConfig(
-            target_size=target_size,
-            output_profile=size_profile,
-        )
+        try:
+            config = ProcessConfig(
+                target_size=target_size,
+                output_profile=size_profile,
+            )
+        except Exception as err:
+            typer.secho(
+                f"Could not apply processing options: {err}", fg=typer.colors.RED
+            )
+            raise typer.Exit(1) from err
+
         cli_process(dest / comic.metadata.title, processing_options, config)
 
     # convert

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -76,6 +76,13 @@ def cli_process(
         )
         raise typer.Exit(1) from err
 
+    if config.output_profile not in all_profiles:
+        typer.secho(
+            f"Invalid profile {config.output_profile}, must be one of {list(all_profiles.keys())}",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
     typer.secho(
         f"Applying processing options: {', '.join(options)}", fg=typer.colors.GREEN
     )
@@ -133,9 +140,10 @@ def process(
     options: list[ProcessOps],
     folder_path: Path = typer.Argument(Path.cwd()),
     target_size: Optional[tuple[int, int]] = typer.Option(
-        None,
+        (0, 0),
         "--target-size",
         "-z",
+        show_default=False,
         help="RESIZE ONLY: The target size (width, height) (cannot be used with `profile`)",
     ),
     size_profile: Optional[str] = typer.Option(
@@ -148,12 +156,9 @@ def process(
     """
     Process a comic folder in-place.
     """
-    if size_profile not in all_profiles:
-        typer.secho(
-            f"Invalid profile {size_profile}, must be one of {all_profiles}",
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(1)
+    # work around typer bug (see mandown get)
+    if target_size == (0, 0):
+        target_size = None
 
     size_profile = cast(SupportedProfiles | None, size_profile)
 
@@ -196,9 +201,10 @@ def get(
         case_sensitive=True,
     ),
     target_size: Optional[tuple[int, int]] = typer.Option(
-        None,
+        (0, 0),
         "--target-size",
         "-z",
+        show_default=False,
         help="IF PROCESSING AND RESIZING: The target size (width, height)",
     ),
     size_profile: Optional[str] = typer.Option(
@@ -219,15 +225,12 @@ def get(
     Defaults to the first chapter and last chapter, respectively
     in the working directory.
     """
+    # work around typer bug (optional of tuples is not parsed correctly)
+    if target_size == (0, 0):
+        target_size = None
+
     if not dest.is_dir():
         raise ValueError(f"{dest} is not a valid folder path.")
-
-    if size_profile not in all_profiles:
-        typer.secho(
-            f"Invalid profile {size_profile}, must be one of {all_profiles}",
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(1)
 
     size_profile = cast(SupportedProfiles | None, size_profile)
 

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import typer
 
-from . import __version_str__, api, sources
+from . import __version_str__, all_profiles, api, sources
 from .comic import BaseComic
 from .converter.base_converter import ConvertFormats
 from .io import MD_METADATA_FILE
@@ -142,6 +142,7 @@ def process(
     """
     Process a comic folder in-place.
     """
+
     config = ProcessConfig(
         target_size=target_size,
         output_profile=size_profile.value if size_profile else None,
@@ -284,6 +285,13 @@ def callback(
         is_eager=True,
         help="Output a list of domains supported by mandown",
     ),
+    list_profiles: bool = typer.Option(
+        False,
+        "--list-profiles",
+        "-l",
+        help="List available device profiles and details",
+        is_eager=True,
+    ),
 ) -> None:
     if version:
         typer.echo(f"mandown {__version_str__}")
@@ -292,6 +300,16 @@ def callback(
     if supported_sites:
         for source in sources.get_all_classes():
             typer.echo(f"{source.name}: {', '.join(source.domains)}")
+        raise typer.Exit()
+
+    if list_profiles:
+        typer.echo("Available profiles:")
+        typer.echo(
+            "\n".join(
+                f' - {profile.name}: "{profile.id}"'
+                for profile in all_profiles.values()
+            )
+        )
         raise typer.Exit()
 
 

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from typing import List, NoReturn, Optional, cast
+from typing import List, Optional, cast
 
 import typer
 

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -136,6 +136,7 @@ def process(
         (0, 0),
         "--target-size",
         "-z",
+        min=0,
         show_default=False,
         help="RESIZE ONLY: The target size (width, height) (cannot be used with `profile`)",
     ),
@@ -202,6 +203,7 @@ def get(
         "--target-size",
         "-z",
         show_default=False,
+        min=0,
         help="IF PROCESSING AND RESIZING: The target size (width, height)",
     ),
     size_profile: Optional[str] = typer.Option(

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import List, NoReturn, Optional, cast
 
 import typer
 
@@ -75,13 +75,6 @@ def cli_process(
             fg=typer.colors.RED,
         )
         raise typer.Exit(1) from err
-
-    if config.output_profile is not None and config.output_profile not in all_profiles:
-        typer.secho(
-            f"Invalid processing profile {config.output_profile}, must be one of {list(all_profiles.keys())}",
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(1)
 
     typer.secho(
         f"Applying processing options: {', '.join(options)}", fg=typer.colors.GREEN
@@ -162,10 +155,15 @@ def process(
 
     size_profile = cast(SupportedProfiles | None, size_profile)
 
-    config = ProcessConfig(
-        target_size=target_size,
-        output_profile=size_profile,
-    )
+    try:
+        config = ProcessConfig(
+            target_size=target_size,
+            output_profile=size_profile,
+        )
+    except ValueError as err:
+        raise typer.Exit(1) from err
+    except KeyError as err:
+        raise typer.Exit(1) from err
     cli_process(folder_path, options, config)
 
 

--- a/mandown/cli.py
+++ b/mandown/cli.py
@@ -76,9 +76,9 @@ def cli_process(
         )
         raise typer.Exit(1) from err
 
-    if config.output_profile not in all_profiles:
+    if config.output_profile is not None and config.output_profile not in all_profiles:
         typer.secho(
-            f"Invalid profile {config.output_profile}, must be one of {list(all_profiles.keys())}",
+            f"Invalid processing profile {config.output_profile}, must be one of {list(all_profiles.keys())}",
             fg=typer.colors.RED,
         )
         raise typer.Exit(1)

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -110,13 +110,12 @@ class Processor(ProcessContainer):
         if ProcessOps.NO_POSTPROCESSING in operations:
             return
 
-        target_size_with_resize = bool(self.config.target_size) ^ bool(
-            ProcessOps.RESIZE in operations
-        )
-        profile_with_resize = bool(self.config.output_profile) ^ bool(
-            ProcessOps.RESIZE in operations
-        )
-        if not target_size_with_resize and not profile_with_resize:
+        # TODO: move all the checks together
+        # there are some in ProcessConfig rn
+        resize_op_valid = bool(
+            self.config.output_profile or self.config.target_size
+        ) ^ bool(ProcessOps.RESIZE in operations)
+        if resize_op_valid:
             # if any of the following is true:
             # - target_size is set and resize is not
             # - profile is set and resize is not

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -110,10 +110,19 @@ class Processor(ProcessContainer):
         if ProcessOps.NO_POSTPROCESSING in operations:
             return
 
-        if bool(self.config.target_size) ^ bool(ProcessOps.RESIZE in operations):
-            # if exactly one of target_size and resize is set
+        target_size_with_resize = bool(self.config.target_size) ^ bool(
+            ProcessOps.RESIZE in operations
+        )
+        profile_with_resize = bool(self.config.output_profile) ^ bool(
+            ProcessOps.RESIZE in operations
+        )
+        if not target_size_with_resize and not profile_with_resize:
+            # if any of the following is true:
+            # - target_size is set and resize is not
+            # - profile is set and resize is not
+            # - resize is set and neither target_size nor profile is set
             raise ProcessOptionMismatchError(
-                "target_size is set but resize is not in operations"
+                "resize must be used with target_size or profile"
             )
 
         for func in operations:

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -21,8 +21,6 @@ except ImportError:
 class ProcessSizeProfiles(str, Enum):
     """
     A class for storing size profiles for processing images.
-
-    :param `target_size`: The target size for the image. Only used if `resize` is enabled.
     """
 
     MOBILE = "mobile"

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -18,30 +18,6 @@ except ImportError:
                 pass
 
 
-class ProcessSizeProfiles(str, Enum):
-    """
-    A class for storing size profiles for processing images.
-    """
-
-    MOBILE = "mobile"
-    """A size profile for mobile devices."""
-
-    TABLET = "tablet"
-    """A size profile for tablet devices."""
-
-    DESKTOP = "desktop"
-    """A size profile for desktop devices."""
-
-    @property
-    def target_size(self) -> tuple[int, int]:
-        """The target size for the image. Only used if `resize` is enabled."""
-        return {
-            self.MOBILE: (1080, 1920),
-            self.TABLET: (1440, 2560),
-            self.DESKTOP: (1920, 1080),
-        }[self]
-
-
 class ProcessOps(str, Enum):
     ROTATE_DOUBLE_PAGES = "rotate_double_pages"
     """If page width is greater than its height, rotate it 90 degrees."""

--- a/mandown/processor/__init__.py
+++ b/mandown/processor/__init__.py
@@ -18,6 +18,32 @@ except ImportError:
                 pass
 
 
+class ProcessSizeProfiles(str, Enum):
+    """
+    A class for storing size profiles for processing images.
+
+    :param `target_size`: The target size for the image. Only used if `resize` is enabled.
+    """
+
+    MOBILE = "mobile"
+    """A size profile for mobile devices."""
+
+    TABLET = "tablet"
+    """A size profile for tablet devices."""
+
+    DESKTOP = "desktop"
+    """A size profile for desktop devices."""
+
+    @property
+    def target_size(self) -> tuple[int, int]:
+        """The target size for the image. Only used if `resize` is enabled."""
+        return {
+            self.MOBILE: (1080, 1920),
+            self.TABLET: (1440, 2560),
+            self.DESKTOP: (1920, 1080),
+        }[self]
+
+
 class ProcessOps(str, Enum):
     ROTATE_DOUBLE_PAGES = "rotate_double_pages"
     """If page width is greater than its height, rotate it 90 degrees."""

--- a/mandown/processor/ops.py
+++ b/mandown/processor/ops.py
@@ -27,7 +27,8 @@ class ProcessConfig:
 
     :param `target_size`: The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`.
     :param `output_profile`: The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`.
-    :raises `ValueError`: If incompatible options are supplied or if the `output_profile` is not a real key (see mandown/processor/profiles.py).
+    :raises `ValueError`: If incompatible options are supplied
+    :raises `KeyError`: `output_profile` is not a real key (see mandown/processor/profiles.py).
     """
 
     target_size: tuple[int, int] | None = None
@@ -44,7 +45,9 @@ class ProcessConfig:
 
         if self.output_profile is not None:
             if self.output_profile not in all_profiles:
-                raise ValueError(f"Invalid output profile: {self.output_profile}.")
+                raise KeyError(
+                    f"Invalid output profile: {self.output_profile}. See mandown.all_profiles or mandown --list-profiles for a list of valid profiles."
+                )
             self.target_size = all_profiles[self.output_profile].size
 
 

--- a/mandown/processor/ops.py
+++ b/mandown/processor/ops.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .profiles import all_profiles
+
 try:
     from PIL import Image, ImageChops
 
@@ -23,11 +25,27 @@ class ProcessConfig:
     """
     A class for storing configuration for processing images.
 
-    :param `target_size`: The target size for the image. Only used if `resize` is enabled.
+    :param `target_size`: The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`.
+    :param `output_profile`: The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`.
+    :raises `ValueError`: If incompatible options are supplied or if the `output_profile` is not a real key (see mandown/processor/profiles.py).
     """
 
     target_size: tuple[int, int] | None = None
-    """The target size for the image. Only used if `resize` is enabled."""
+    """The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`."""
+
+    output_profile: str | None = None
+    """The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`."""
+
+    def __post_init__(self) -> None:
+        if self.target_size is not None and self.output_profile is not None:
+            raise ValueError(
+                "Only one of `target_size` or `output_profile` can be specified."
+            )
+
+        if self.output_profile is not None:
+            if self.output_profile not in all_profiles:
+                raise ValueError(f"Invalid output profile: {self.output_profile}.")
+            self.target_size = all_profiles[self.output_profile].size
 
 
 class ProcessContainer:

--- a/mandown/processor/ops.py
+++ b/mandown/processor/ops.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from .profiles import all_profiles
+from .profiles import SupportedProfiles, all_profiles
 
 try:
     from PIL import Image, ImageChops
@@ -33,7 +33,7 @@ class ProcessConfig:
     target_size: tuple[int, int] | None = None
     """The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`."""
 
-    output_profile: str | None = None
+    output_profile: SupportedProfiles | None = None
     """The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`."""
 
     def __post_init__(self) -> None:

--- a/mandown/processor/ops.py
+++ b/mandown/processor/ops.py
@@ -25,17 +25,25 @@ class ProcessConfig:
     """
     A class for storing configuration for processing images.
 
-    :param `target_size`: The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`.
-    :param `output_profile`: The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`.
+    :param `target_size`: The target size for the image. Only
+    used if `resize` is enabled. Mutually exclusive with `output_profile`.
+    :param `output_profile`: The output size profile to use for
+    the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`.
     :raises `ValueError`: If incompatible options are supplied
     :raises `KeyError`: `output_profile` is not a real key (see mandown/processor/profiles.py).
     """
 
     target_size: tuple[int, int] | None = None
-    """The target size for the image. Only used if `resize` is enabled. Mutually exclusive with `output_profile`."""
+    """
+    The target size for the image. Only used if `resize`
+    is enabled. Mutually exclusive with `output_profile`.
+    """
 
     output_profile: SupportedProfiles | None = None
-    """The output size profile to use for the image. Only used if `resize` is enabled. Mutually exclusive with `target_size`."""
+    """
+    The output size profile to use for the image. Only
+    used if `resize` is enabled. Mutually exclusive with `target_size`.
+    """
 
     def __post_init__(self) -> None:
         if self.target_size is not None and self.output_profile is not None:
@@ -46,7 +54,8 @@ class ProcessConfig:
         if self.output_profile is not None:
             if self.output_profile not in all_profiles:
                 raise KeyError(
-                    f"Invalid output profile: {self.output_profile}. See mandown.all_profiles or mandown --list-profiles for a list of valid profiles."
+                    f"Invalid output profile: {self.output_profile}. See mandown."
+                    "all_profiles or mandown --list-profiles for a list of valid profiles."
                 )
             self.target_size = all_profiles[self.output_profile].size
 

--- a/mandown/processor/profiles.py
+++ b/mandown/processor/profiles.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
 
 
 @dataclass(slots=True, frozen=True)
@@ -8,15 +10,36 @@ class OutputProfile:
     size: tuple[int, int]
 
 
+SupportedProfiles = Literal[
+    "kindle",
+    "kintouch",
+    "paper",
+    "voyage",
+    "oasis2",
+    "kobotouch",
+    "glo",
+    "glohd",
+    "aura",
+    "aurahd",
+    "aurah2o",
+    "aurah2o2",
+    "auraone",
+    "clarahd",
+    "librah2o",
+    "nia",
+    "clara2e",
+    "libra2",
+    "sage",
+]
 _ProfileType = tuple[str, tuple[int, int]]
 
-__all_profiles_data: dict[str, _ProfileType] = {
+__all_profiles_data: dict[SupportedProfiles, _ProfileType] = {
     # Kindles
     "kindle": ("Kindle", (600, 800)),
     "kintouch": ("Kindle Touch", (600, 800)),
     "paper": ("Kindle Paperwhite 1/2", (758, 1024)),
     "voyage": ("Kindle Voyage, Oasis, Paperwhite 3/4", (1072, 1448)),
-    "oasis": ("Kindle Oasis 2/3", (1264, 1680)),
+    "oasis2": ("Kindle Oasis 2/3", (1264, 1680)),
     # Kobos
     "kobotouch": ("Kobo Mini/Touch", (600, 800)),
     "glo": ("Kobo Glo", (768, 1024)),
@@ -37,3 +60,7 @@ __all_profiles_data: dict[str, _ProfileType] = {
 all_profiles = {
     id: OutputProfile(id, *profile) for id, profile in __all_profiles_data.items()
 }
+
+SupportedProfilesEnum = Enum(
+    "SupportedProfilesEnum", {id: id for id in __all_profiles_data}
+)

--- a/mandown/processor/profiles.py
+++ b/mandown/processor/profiles.py
@@ -60,7 +60,3 @@ __all_profiles_data: dict[SupportedProfiles, _ProfileType] = {
 all_profiles = {
     id: OutputProfile(id, *profile) for id, profile in __all_profiles_data.items()
 }
-
-SupportedProfilesEnum = Enum(
-    "SupportedProfilesEnum", {id: id for id in __all_profiles_data}
-)

--- a/mandown/processor/profiles.py
+++ b/mandown/processor/profiles.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class OutputProfile:
+    id: str
+    name: str
+    size: tuple[int, int]
+
+
+_ProfileType = tuple[str, tuple[int, int]]
+
+__all_profiles_data: dict[str, _ProfileType] = {
+    # Kindles
+    "kindle": ("Kindle", (600, 800)),
+    "kintouch": ("Kindle Touch", (600, 800)),
+    "paper": ("Kindle Paperwhite 1/2", (758, 1024)),
+    "voyage": ("Kindle Voyage, Oasis, Paperwhite 3/4", (1072, 1448)),
+    "oasis": ("Kindle Oasis 2/3", (1264, 1680)),
+    # Kobos
+    "kobotouch": ("Kobo Mini/Touch", (600, 800)),
+    "glo": ("Kobo Glo", (768, 1024)),
+    "glohd": ("Kobo Glo HD", (1072, 1448)),
+    "aura": ("Kobo Aura", (758, 1024)),
+    "aurahd": ("Kobo Aura HD", (1080, 1440)),
+    "aurah2o": ("Kobo Aura H2O", (1080, 1430)),
+    "aurah2o2": ("Kobo Aura H2O 2", (1080, 1430)),
+    "auraone": ("Kobo Aura One", (1404, 1872)),
+    "clarahd": ("Kobo Clara HD", (1072, 1448)),
+    "librah2o": ("Kobo Libra H2O", (1264, 1680)),
+    "nia": ("Kobo Nia", (758, 1024)),
+    "clara2e": ("Kobo Clara 2E", (1072, 1448)),
+    "libra2": ("Kobo Libra 2", (1264, 1680)),
+    "sage": ("Kobo Sage", (1440, 1920)),
+}
+
+all_profiles = {
+    id: OutputProfile(id, *profile) for id, profile in __all_profiles_data.items()
+}

--- a/mandown/processor/profiles.py
+++ b/mandown/processor/profiles.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Literal
 
 


### PR DESCRIPTION
This PR does a lot of reshuffling but is mostly for the addition of the following features:

```
mandown process resize --target-size XXX XXX
```
where XXX is any non-negative integer (width, height).

OR

```
mandown process resize --profile PROFILE
```
where PROFILE is any one of the device IDs found via `mandown --list-profiles` (includes a lot of ereaders).

It also changes the `mandown.process{_progress}` interface to optionally pass in a `ProcessConfig` object that may be used to pass in extra flags for the processor.

A lot of Mandown functions have now been imported into the main namespace too for consumption. 
