### PR TITLE
Fix PDF converter stuff

### DIFF
--- a/mandown/converter/pdf.py
+++ b/mandown/converter/pdf.py
@@ -44,14 +44,14 @@ class PdfConverter(BaseConverter):
         interval = round(
             min(
                 PDF_IMAGE_MAX_INTERVAL,
-                len(images) * PDF_IMAGE_MIN_INTERVAL_FACTOR,
+                max(1, len(images) * PDF_IMAGE_MIN_INTERVAL_FACTOR)
             )
         )
 
         dest_file = save_to / (self.comic.metadata.title + ".pdf")
         for i in range(0, len(images), interval):
             append_images = (
-                images[i + 1 : i + interval] if len(images) > i + 1 else None
+                images[i + 1 : i + interval] if len(images) > i + 1 else []
             )
             author = (
                 self.comic.metadata.authors[0] if self.comic.metadata.authors else ""

--- a/mandown/converter/pdf.py
+++ b/mandown/converter/pdf.py
@@ -27,11 +27,14 @@ class PdfConverter(BaseConverter):
         path = Path(path)
         save_to = Path(save_to)
 
-        images: list[Image.Image] = [
-            Image.open(f)
-            for f in sorted(Path.rglob(path, "*"))
-            if f.suffix in ACCEPTED_IMAGE_EXTENSIONS
-        ]
+        images: list[Image.Image] = []
+        for chap in self.comic.chapters:
+            images.extend([
+                Image.open(f)
+                for f in sorted((path / chap.slug).iterdir())
+                if f.suffix in ACCEPTED_IMAGE_EXTENSIONS
+            ])
+
 
         if len(images) < 0:
             raise IOError("No images to convert found")


### PR DESCRIPTION
Previously, the PDF converter just stitches together all image files in the directory, so for comics where the chapter titles aren't `Chapter-001` or similar, the chapters may be joined out of order. For example:
```
mandown get 'https://mangadex.org/title/34f45c13-2b78-4900-8af2-d0bb551101f4/dorohedoro' --start 1 --end 2 --convert pdf
```
This PR makes it so chapters are joined in the order specified in the metadata, which is consistent with the epub converter (although like with the epub converter, covers are no longer included... not sure what you want to do about this).

Also, this PR fixes a bug where the pdf converter doesn't work for chapters with very few pages, ex.
```
mandown get 'https://mangadex.org/title/f9c33607-9180-4ba6-b85c-e4b5faee7192/official-test-manga' --start 1 --end 1 --convert pdf
```